### PR TITLE
Update pre commit configuration file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  # Websec hook is MANDATORY, DO NOT comment it.
+  - repo: https://github.com/mercadolibre/fury_websec-git-hooks
+    rev: v1.0.0
+    hooks:
+      - id: pre_commit_hook
+        stages: [commit]
+      - id: post_commit_hook
+        stages: [post-commit]


### PR DESCRIPTION
### This PR adds the pre-commit configurations to use websec hook.

This PR was created automatically by [websec](https://sites.google.com/mercadolibre.com/websec), please review it to check only the websec-hook configuration is added.
Lines expected to be added:

```
repos:
  - repo: https://github.com/mercadolibre/fury_websec-git-hooks
    rev: v1.0.0
    hooks:
      - id: pre_commit_hook
        stages: [commit]
      - id: post_commit_hook
        stages: [post-commit]
```

More information on [workplace post](https://meli.workplace.com/groups/942637169155799/permalink/5076719172414224/).

**Websec's pre-commit hook is mandatory. Feel free to add/remove/modify any other hook except the websec's one.**

> If you have any questions contact by mail to websec@ or by Slack channel #tech-websec.
