### PR TITLE
Raw error attribute in job model

### DIFF
--- a/lib/little_monster/core/job.rb
+++ b/lib/little_monster/core/job.rb
@@ -92,7 +92,7 @@ module LittleMonster::Core
       end
     end
 
-    attr_accessor :id, :tags, :status, :retries, :current_action, :data, :error
+    attr_accessor :id, :tags, :status, :retries, :current_action, :data, :error, :raw_error
 
     attr_reader :orchrestator
 

--- a/lib/little_monster/core/job_orchrestator.rb
+++ b/lib/little_monster/core/job_orchrestator.rb
@@ -182,6 +182,7 @@ module LittleMonster::Core
       end
 
       @job.error = @job.serialize_error error
+      @job.raw_error = error
 
       if error.is_a?(FatalTaskError) || error.is_a?(NameError)
         logger.debug 'error is fatal, aborting run'

--- a/spec/lib/little_monster/core/job_orchrestator_spec.rb
+++ b/spec/lib/little_monster/core/job_orchrestator_spec.rb
@@ -626,6 +626,13 @@ describe LittleMonster::Core::Job::Orchrestator do
         subject.handle_error error
         expect(subject).to have_received(:do_retry).with error
       end
+
+      it 'sets error and raw_error' do
+        error = LittleMonster::TaskError.new
+        subject.handle_error error
+        expect(subject.job.error).to eq(message: error.message, type: error.class.to_s, retry: subject.job.retries)
+        expect(subject.job.raw_error).to eq(error)
+      end
     end
   end
 


### PR DESCRIPTION
### Summary
This pr adds `raw_error` new attribute in job model.

This allows any gem implementation to manipulate error as it was created, giving the possibility to access error's inner fields without serialization.